### PR TITLE
feat: allow hidden badge without container element

### DIFF
--- a/packages/react-recaptcha-v3/src/ReCaptchaProvider.tsx
+++ b/packages/react-recaptcha-v3/src/ReCaptchaProvider.tsx
@@ -192,21 +192,6 @@ export default function ReCaptchaProvider({
 
     const nextClientId = reCaptchaInstance.render(actualContainerElement, params);
 
-    if (container?.parameters?.hidden) {
-      if (!didWarnAboutHiddenBadge) {
-        warning(
-          false,
-          'reCAPTCHA badge hidden. See https://cloud.google.com/recaptcha/docs/faq#id_like_to_hide_the_badge_what_is_allowed for more information.',
-        );
-
-        didWarnAboutHiddenBadge = true;
-      }
-
-      (
-        actualContainerElement.querySelector('.grecaptcha-badge') as HTMLDivElement | null
-      )?.style.setProperty('display', 'none');
-    }
-
     setClientId(nextClientId);
     clientIdMounted.current = true;
 
@@ -221,7 +206,6 @@ export default function ReCaptchaProvider({
   }, [
     container?.element,
     container?.parameters?.badge,
-    container?.parameters?.hidden,
     container?.parameters?.callback,
     container?.parameters?.errorCallback,
     container?.parameters?.expiredCallback,
@@ -230,6 +214,24 @@ export default function ReCaptchaProvider({
     reCaptchaInstance,
     reCaptchaKey,
   ]);
+
+  useEffect(() => {
+    if (container?.parameters?.hidden && !!reCaptchaInstance?.execute) {
+      if (!didWarnAboutHiddenBadge) {
+        warning(
+          false,
+          'reCAPTCHA badge hidden. See https://cloud.google.com/recaptcha/docs/faq#id_like_to_hide_the_badge_what_is_allowed for more information.',
+        );
+
+        didWarnAboutHiddenBadge = true;
+      }
+
+      (document.querySelector('.grecaptcha-badge') as HTMLDivElement | null)?.style.setProperty(
+        'display',
+        'none',
+      );
+    }
+  }, [container?.parameters?.hidden, reCaptchaInstance?.execute]);
 
   const shouldUseClientId = Boolean(container?.element);
   const clientIdOrReCaptchaKey = shouldUseClientId ? clientId : reCaptchaKey;

--- a/test/Test.tsx
+++ b/test/Test.tsx
@@ -25,6 +25,7 @@ export default function Test() {
   const [showInstance2, setShowInstance2Internal] = useState(false);
   const [showInstance3, setShowInstance3Internal] = useState(false);
   const [showInstance4, setShowInstance4Internal] = useState(false);
+  const [showInstance5, setShowInstance5Internal] = useState(false);
 
   const containerId2 = useId();
   const containerId3 = useId();
@@ -33,6 +34,7 @@ export default function Test() {
   const [token2, setToken2] = useState('');
   const [token3, setToken3] = useState('');
   const [token4, setToken4] = useState('');
+  const [token5, setToken5] = useState('');
 
   function setShowInstance1(value: boolean) {
     setShowInstance1Internal(value);
@@ -62,6 +64,13 @@ export default function Test() {
     }
   }
 
+  function setShowInstance5(value: boolean) {
+    setShowInstance5Internal(value);
+    if (!value) {
+      setToken5('');
+    }
+  }
+
   return (
     <div className="Test">
       <header>
@@ -82,10 +91,12 @@ export default function Test() {
             setShowInstance2={setShowInstance2}
             setShowInstance3={setShowInstance3}
             setShowInstance4={setShowInstance4}
+            setShowInstance5={setShowInstance5}
             showInstance1={showInstance1}
             showInstance2={showInstance2}
             showInstance3={showInstance3}
             showInstance4={showInstance4}
+            showInstance5={showInstance5}
           />
         </aside>
         <main className="Test__container__content">
@@ -106,6 +117,27 @@ export default function Test() {
             <>
               <h2>Instance 2</h2>
               <ReCaptchaProvider
+                reCaptchaKey={reCaptchaKey}
+                scriptProps={scriptProps}
+                container={{
+                  parameters: {
+                    hidden: true,
+                  },
+                }}
+              >
+                <form>
+                  <div>
+                    <output className="Test__container__content__token">{token2}</output>
+                    <ReCaptcha onVerify={setToken2} />
+                  </div>
+                </form>
+              </ReCaptchaProvider>
+            </>
+          ) : null}
+          {showInstance3 ? (
+            <>
+              <h2>Instance 3</h2>
+              <ReCaptchaProvider
                 container={{
                   element: containerId2,
                   parameters: {
@@ -117,16 +149,16 @@ export default function Test() {
                 <form>
                   <div>
                     <div id={containerId2} />
-                    <ReCaptcha onVerify={setToken2} />
-                    <output className="Test__container__content__token">{token2}</output>
+                    <ReCaptcha onVerify={setToken3} />
+                    <output className="Test__container__content__token">{token3}</output>
                   </div>
                 </form>
               </ReCaptchaProvider>
             </>
           ) : null}
-          {showInstance3 ? (
+          {showInstance4 ? (
             <>
-              <h2>Instance 3</h2>
+              <h2>Instance 4</h2>
               <ReCaptchaProvider
                 container={{
                   element: containerId3,
@@ -140,21 +172,21 @@ export default function Test() {
                 <form>
                   <div>
                     <div id={containerId3} />
-                    <ReCaptcha onVerify={setToken3} />
-                    <output className="Test__container__content__token">{token3}</output>
+                    <ReCaptcha onVerify={setToken4} />
+                    <output className="Test__container__content__token">{token4}</output>
                   </div>
                 </form>
               </ReCaptchaProvider>
             </>
           ) : null}
-          {showInstance4 ? (
+          {showInstance5 ? (
             <>
-              <h2>Instance 4</h2>
+              <h2>Instance 5</h2>
               <ReCaptchaProvider reCaptchaKey={reCaptchaKey} useEnterprise useRecaptchaNet>
                 <form>
                   <div>
-                    <ReCaptcha onVerify={setToken4} />
-                    <output className="Test__container__content__token">{token4}</output>
+                    <ReCaptcha onVerify={setToken5} />
+                    <output className="Test__container__content__token">{token5}</output>
                   </div>
                 </form>
               </ReCaptchaProvider>

--- a/test/VisibilityOptions.tsx
+++ b/test/VisibilityOptions.tsx
@@ -7,6 +7,8 @@ type VisibilityOptionsProps = {
   setShowInstance3: (value: boolean) => void;
   showInstance4: boolean;
   setShowInstance4: (value: boolean) => void;
+  showInstance5: boolean;
+  setShowInstance5: (value: boolean) => void;
 };
 
 export default function VisibilityOptions({
@@ -18,6 +20,8 @@ export default function VisibilityOptions({
   setShowInstance3,
   showInstance4,
   setShowInstance4,
+  showInstance5,
+  setShowInstance5,
 }: VisibilityOptionsProps) {
   function onShowInstance1Change(event: React.ChangeEvent<HTMLInputElement>) {
     setShowInstance1(event.target.checked);
@@ -33,6 +37,10 @@ export default function VisibilityOptions({
 
   function onShowInstance4Change(event: React.ChangeEvent<HTMLInputElement>) {
     setShowInstance4(event.target.checked);
+  }
+
+  function onShowInstance5Change(event: React.ChangeEvent<HTMLInputElement>) {
+    setShowInstance5(event.target.checked);
   }
 
   return (
@@ -56,7 +64,8 @@ export default function VisibilityOptions({
           checked={showInstance2}
           onChange={onShowInstance2Change}
         />
-        <label htmlFor="showInstance2">Show instance 2</label> <small>(inline badge)</small>
+        <label htmlFor="showInstance2">Show instance 2</label>{' '}
+        <small>(default badge, hidden)</small>
       </div>
 
       <div>
@@ -66,8 +75,7 @@ export default function VisibilityOptions({
           checked={showInstance3}
           onChange={onShowInstance3Change}
         />
-        <label htmlFor="showInstance3">Show instance 3</label>{' '}
-        <small>(inline badge, too; hidden badge; use to test multiple instances)</small>
+        <label htmlFor="showInstance3">Show instance 3</label> <small>(inline badge)</small>
       </div>
 
       <div>
@@ -78,6 +86,17 @@ export default function VisibilityOptions({
           onChange={onShowInstance4Change}
         />
         <label htmlFor="showInstance4">Show instance 4</label>{' '}
+        <small>(inline badge, too; hidden badge; use to test multiple instances)</small>
+      </div>
+
+      <div>
+        <input
+          id="showInstance5"
+          type="checkbox"
+          checked={showInstance5}
+          onChange={onShowInstance5Change}
+        />
+        <label htmlFor="showInstance5">Show instance 5</label>{' '}
         <small>(different settings; should crash unless 1 and 2 are hidden)</small>
       </div>
     </fieldset>


### PR DESCRIPTION
Adds the ability to hide the badge by passing the container prop to the provider without setting a custom element. 

I'm assuming that `document.querySelector` and `actualContainerElement.querySelector` are similarly performant. Added a new test case for this.